### PR TITLE
KRACOEUS-8594 : Fix for blank country codes throwing exceptions

### DIFF
--- a/coeus-s2sgen-impl/src/main/java/org/kuali/coeus/s2sgen/impl/location/S2SLocationServiceImpl.java
+++ b/coeus-s2sgen-impl/src/main/java/org/kuali/coeus/s2sgen/impl/location/S2SLocationServiceImpl.java
@@ -1,5 +1,6 @@
 package org.kuali.coeus.s2sgen.impl.location;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kuali.coeus.common.api.country.CountryContract;
 import org.kuali.coeus.common.api.country.KcCountryService;
 import org.kuali.coeus.common.api.state.KcStateService;
@@ -27,7 +28,7 @@ public class S2SLocationServiceImpl implements S2SLocationService {
      */
     @Override
     public CountryContract getCountryFromCode(String countryCode) {
-        if(countryCode==null) return null;
+        if(StringUtils.isBlank(countryCode)) return null;
         CountryContract country = getKcCountryService().getCountryByAlternateCode(countryCode);
         if(country==null){
             country = getKcCountryService().getCountry(countryCode);


### PR DESCRIPTION
KcCountryService both throw IllegalArgumentException if the country code is blank, but blank country codes are allowed by validations. This was discovered and fixed in CX and instead of forking this project unnecessarily, I'm fixing it here.
